### PR TITLE
Update multiarch support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -21,16 +21,17 @@ jobs:
         id: set_build_args
         shell: bash
         run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: Build and Push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           push: true
           tags: |
             mrsaints/kubeseal-web:latest
-            mrsaints/kubeseal-web:${{ steps.set_build_args.outputs.sha_short }}
+            mrsaints/kubeseal-web:${{ env.sha_short }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v6
           build-args: |
-            BUILD_VERSION=${{ steps.set_build_args.outputs.sha_short }}
+            BUILD_VERSION=${{ env.sha_short }}
       - name: Image Digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,10 @@ LABEL org.label-schema.vcs-url="https://github.com/MrSaints/kubeseal-web" \
 
 RUN apk add --no-cache bash ca-certificates curl jq wget nano
 
-RUN KUBESEAL_BIN="kubeseal-linux-${TARGETARCH}" \
-    && wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.13.1/${KUBESEAL_BIN} -O kubeseal \
-    && install -m 755 kubeseal /usr/local/bin/kubeseal \
-    && rm kubeseal
+# Check required to handle naming convention in kubeseal assets as it doesnt contain the "linux-" prefix
+RUN KUBESEAL_BIN="kubeseal$(if [ "${TARGETARCH}" = "arm" ]; then echo "-${TARGETARCH}"; else echo "-linux-${TARGETARCH}"; fi)" \
+    && wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.13.1/$KUBESEAL_BIN -O /usr/local/bin/kubeseal \
+    && chmod +x /usr/local/bin/kubeseal
 
 COPY --from=build /build/kubeseal-web /kubeseal-web/run
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,10 @@ LABEL org.label-schema.vcs-url="https://github.com/MrSaints/kubeseal-web" \
 
 RUN apk add --no-cache bash ca-certificates curl jq wget nano
 
-# Check required to handle naming convention in kubeseal assets as it doesnt contain the "linux-" prefix
-RUN KUBESEAL_BIN="kubeseal$(if [ "${TARGETARCH}" = "arm" ]; then echo "-${TARGETARCH}"; else echo "-linux-${TARGETARCH}"; fi)" \
-    && wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.13.1/$KUBESEAL_BIN -O /usr/local/bin/kubeseal \
-    && chmod +x /usr/local/bin/kubeseal
+RUN wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.17.3/kubeseal-0.17.3-linux-${TARGETARCH}.tar.gz -O kubeseal.tar.gz \
+    && tar -xzf kubeseal.tar.gz -C /tmp/ \
+    && install -m 755 /tmp/kubeseal /usr/local/bin/kubeseal \
+    && rm -rf kubeseal.tar.gz /tmp/kubeseal
 
 COPY --from=build /build/kubeseal-web /kubeseal-web/run
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM golang:1.15-alpine AS dev
+# syntax=docker/dockerfile:1.2
+
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine AS dev
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
 
 LABEL org.label-schema.vcs-url="https://github.com/MrSaints/kubeseal-web" \
       maintainer="Ian L. <os@fyianlai.com>"
@@ -15,35 +20,37 @@ COPY go.mod go.sum /kubeseal-web/
 RUN go mod download \
     && go get github.com/markbates/pkger/cmd/pkger
 
-
-FROM dev as build
+FROM --platform=$BUILDPLATFORM dev AS build
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
 
 COPY ./ /kubeseal-web/
 
-RUN mkdir /build/
-
-RUN pkger -include /static/ \
-    && rm -rf /kubeseal-web/static/
-
-RUN CGO_ENABLED=0 \
-    go build -v \
-    -ldflags "-s" -a -installsuffix cgo \
-    -o /build/kubeseal-web \
-    /kubeseal-web/ \
+RUN mkdir /build/ \
+    && pkger -include /static/ \
+    && rm -rf /kubeseal-web/static/ \
+    && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v \
+       -ldflags "-s -w" -a -installsuffix cgo \
+       -o /build/kubeseal-web . \
     && chmod +x /build/kubeseal-web
 
-
-FROM alpine:3.12 AS prod
+FROM --platform=$TARGETPLATFORM alpine:3.12 AS prod
+ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
 
 LABEL org.label-schema.vcs-url="https://github.com/MrSaints/kubeseal-web" \
       maintainer="Ian L. <os@fyianlai.com>"
 
 RUN apk add --no-cache bash ca-certificates curl jq wget nano
 
-COPY --from=build /build/kubeseal-web /kubeseal-web/run
+RUN KUBESEAL_BIN="kubeseal-linux-${TARGETARCH}" \
+    && wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.13.1/${KUBESEAL_BIN} -O kubeseal \
+    && install -m 755 kubeseal /usr/local/bin/kubeseal \
+    && rm kubeseal
 
-RUN curl -sL https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.13.1/kubeseal-linux-amd64 -o /usr/local/bin/kubeseal
-RUN chmod +x /usr/local/bin/kubeseal
+COPY --from=build /build/kubeseal-web /kubeseal-web/run
 
 ARG BUILD_VERSION
 ENV KSWEB_VERSION $BUILD_VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,31 @@
 module github.com/mrsaints/kubeseal-web
 
-go 1.15
+go 1.19
 
 require (
 	github.com/gin-contrib/zap v0.0.1
 	github.com/gin-gonic/gin v1.6.3
-	github.com/gobuffalo/here v0.6.2 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/markbates/pkger v0.17.1
 	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.10.0
+)
+
+require (
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/go-playground/validator/v10 v10.2.0 // indirect
+	github.com/gobuffalo/here v0.6.2 // indirect
+	github.com/golang/protobuf v1.3.3 // indirect
+	github.com/json-iterator/go v1.1.9 // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
+	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
+	github.com/ugorji/go/codec v1.1.7 // indirect
+	go.uber.org/atomic v1.3.2 // indirect
+	go.uber.org/multierr v1.1.0 // indirect
+	golang.org/x/sys v0.0.0-20200116001909-b77594299b42 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,7 +18,6 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1Vv0sFl1UcHBOY=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
-github.com/gobuffalo/here v0.6.0 h1:hYrd0a6gDmWxBM4TnrGw8mQg24iSVoIkHEk7FodQcBI=
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/gobuffalo/here v0.6.2 h1:ZtCqC7F9ou3moLbYfHM1Tj+gwHGgWhjyRjVjsir9BE0=
 github.com/gobuffalo/here v0.6.2/go.mod h1:D75Sq0p2BVHdgQu3vCRsXbg85rx943V19urJpqAVWjI=
@@ -31,7 +30,6 @@ github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGn
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -57,11 +55,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
@@ -77,7 +73,6 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
1) Bump go to 1.19 and ran `go mod tidy`
2) Updated Dockerfile to support multi-arch
3) Updated CI file with new workflow versions and specify platform to build

`KUBESEAL_BIN` in Dockerfile should be able to reference kubeseal assets from `0.13.1` release here:
- https://github.com/bitnami-labs/sealed-secrets/releases/tag/v0.13.1